### PR TITLE
"Dim" unnecessary code (e.g unused vars)

### DIFF
--- a/src/Bicep.Core/Analyzers/Interfaces/IBicepAnalyzerRule.cs
+++ b/src/Bicep.Core/Analyzers/Interfaces/IBicepAnalyzerRule.cs
@@ -19,6 +19,7 @@ namespace Bicep.Core.Analyzers.Interfaces
         string Code { get; }
         string Description { get; }
         DiagnosticLevel DiagnosticLevel { get; }
+        DiagnosticLabel? DiagnosticLabel { get; }
         string DocumentationUri { get; }
         string RuleName { get; }
         bool Enabled { get; }

--- a/src/Bicep.Core/Analyzers/Linter/LinterRuleBase.cs
+++ b/src/Bicep.Core/Analyzers/Linter/LinterRuleBase.cs
@@ -16,7 +16,8 @@ namespace Bicep.Core.Analyzers.Linter
     public abstract class LinterRuleBase : IBicepAnalyzerRule
     {
         public LinterRuleBase(string code, string ruleName, string description, string docUri,
-                          DiagnosticLevel diagnosticLevel = DiagnosticLevel.Warning)
+                          DiagnosticLevel diagnosticLevel = DiagnosticLevel.Warning,
+                          DiagnosticLabel? diagnosticLabel = null)
         {
             this.ConfigHelper = new ConfigHelper();
             this.AnalyzerName = LinterAnalyzer.AnalyzerName;
@@ -26,6 +27,7 @@ namespace Bicep.Core.Analyzers.Linter
             this.DocumentationUri = docUri;
 
             this.DiagnosticLevel = diagnosticLevel;
+            this.DiagnosticLabel = diagnosticLabel;
 
             LoadConfiguration();
         }
@@ -45,13 +47,16 @@ namespace Bicep.Core.Analyzers.Linter
 
         public bool Enabled => this.DiagnosticLevel != DiagnosticLevel.Off;
         public Diagnostics.DiagnosticLevel DiagnosticLevel { get; private set; }
+
         public string Description { get; }
         public string DocumentationUri { get; }
+        public Diagnostics.DiagnosticLabel? DiagnosticLabel { get; }
 
         private void LoadConfiguration()
         {
             var configDiagLevel = GetConfiguration(nameof(this.DiagnosticLevel), this.DiagnosticLevel.ToString());
-            if(DiagnosticLevel.TryParse<DiagnosticLevel>(configDiagLevel, true, out var lvl)){
+            if (DiagnosticLevel.TryParse<DiagnosticLevel>(configDiagLevel, true, out var lvl))
+            {
                 this.DiagnosticLevel = lvl;
             }
         }
@@ -122,7 +127,8 @@ namespace Bicep.Core.Analyzers.Linter
                 span: span,
                 level: this.DiagnosticLevel,
                 code: this.Code,
-                message: this.GetMessage());
+                message: this.GetMessage(),
+                label: this.DiagnosticLabel);
 
         /// <summary>
         /// Create a diagnostic message for a span that has a customized string
@@ -136,7 +142,8 @@ namespace Bicep.Core.Analyzers.Linter
                 span: span,
                 level: this.DiagnosticLevel,
                 code: this.Code,
-                message: this.GetFormattedMessage(values));
+                message: this.GetFormattedMessage(values),
+                label: this.DiagnosticLabel);
 
         internal virtual AnalyzerFixableDiagnostic CreateFixableDiagnosticForSpan(TextSpan span, CodeFix fix) =>
             new(analyzerName: this.AnalyzerName,
@@ -145,7 +152,7 @@ namespace Bicep.Core.Analyzers.Linter
                 code: this.Code,
                 message: this.GetMessage(),
                 codeFixes: new[] { fix },
-                label: null);
+                label: this.DiagnosticLabel);
 
     }
 }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/BCPL1010.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/BCPL1010.cs
@@ -15,7 +15,8 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             code: "BCPL1010",
             ruleName: "Parameters must be used",
             description: "Declared parameter must be referenced within the document scope.",
-            docUri: "https://bicep/linter/rules/BCPL1010") // TODO: setup up doc pages
+            docUri: "https://bicep/linter/rules/BCPL1010", // TODO: setup up doc pages
+            diagnosticLabel: Diagnostics.DiagnosticLabel.Unnecessary)
         { }
 
         override internal IEnumerable<IBicepAnalyzerDiagnostic> AnalyzeInternal(SemanticModel model)

--- a/src/Bicep.Core/Analyzers/Linter/Rules/BCPL1050.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/BCPL1050.cs
@@ -13,9 +13,10 @@ namespace Bicep.Core.Analyzers.Linter.Rules
     {
         public BCPL1050() : base(
             code: "BCPL1050",
-            ruleName: "Declared variable not used",
+            ruleName: "Declared variable not used", // TODO: param not used?
             description: "Declared variable encountered that is not used within scope.",
-            docUri: "https://bicep/linter/rules/BCPL1050")// TODO: setup up doc pages
+            docUri: "https://bicep/linter/rules/BCPL1050", // TODO: setup up doc pages
+            diagnosticLabel: Diagnostics.DiagnosticLabel.Unnecessary)
         { }
 
         override internal IEnumerable<IBicepAnalyzerDiagnostic> AnalyzeInternal(SemanticModel model)
@@ -24,7 +25,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             var unreferencedVariables = model.Root.Declarations.OfType<VariableSymbol>()
                                     .Where(sym => !model.FindReferences(sym).OfType<VariableAccessSyntax>().Any());
 
-            foreach(var sym in unreferencedVariables)
+            foreach (var sym in unreferencedVariables)
             {
                 yield return CreateDiagnosticForSpan(sym.NameSyntax.Span);
             }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/BCPL1070.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/BCPL1070.cs
@@ -18,7 +18,8 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             code: "BCPL1070",
             ruleName: "Unecessary dependsOn",
             description: "Best Practice: remove unnecessary dependsOn.",
-            docUri: "https://bicep/linter/rules/BCPL1070") // TODO: setup up doc pages
+            docUri: "https://bicep/linter/rules/BCPL1070", // TODO: setup up doc pages
+            diagnosticLabel: Diagnostics.DiagnosticLabel.Unnecessary)
         { }
 
         override internal IEnumerable<IBicepAnalyzerDiagnostic> AnalyzeInternal(SemanticModel model)


### PR DESCRIPTION
This consists of simply adding the DiagnosticLabel.Unnecessary label to the appropriate diagnostics.